### PR TITLE
Update Proxy.cs

### DIFF
--- a/Youtube-Viewers/Helpers/Proxy.cs
+++ b/Youtube-Viewers/Helpers/Proxy.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions; //RegEx
 using Leaf.xNet;
 
 namespace Youtube_Viewers.Helpers
@@ -16,10 +17,15 @@ namespace Youtube_Viewers.Helpers
 
         public Proxy(string proxy)
         {
+            bool Match = Regex.IsMatch(proxy.Trim(), string.Join(string.Empty, "^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])$:\\d{2,5}"));
+
+            if (Match == true)
+            {
             Address = proxy.Trim();
             Http = HttpProxyClient.Parse(Address);
             Socks4 = Socks4ProxyClient.Parse(Address);
             Socks5 = Socks5ProxyClient.Parse(Address);
+            }
         }
 
         public static List<Proxy> GetList(List<string> list)


### PR DESCRIPTION
Added RegEx Matching for "IP:PORT" during Proxy(string) function before passing Address to proxy.Trim(); some proxy lists have errors or incorrectly formatted proxies that will throw an exception during running. This prevents anything invalid from being passed to Address variable that isn't an IP:PORT.

Includes: using System.Text.RegularExpressions;